### PR TITLE
[Docs] Visualization of the mole-public codebase.

### DIFF
--- a/.codeboarding/Configuration_System.md
+++ b/.codeboarding/Configuration_System.md
@@ -1,0 +1,73 @@
+```mermaid
+
+graph LR
+
+    Configuration_System["Configuration System"]
+
+    Training_Pipeline_Orchestrator["Training Pipeline Orchestrator"]
+
+    Prediction_Pipeline_Orchestrator["Prediction Pipeline Orchestrator"]
+
+    Training_Pipeline_Orchestrator -- "Configures" --> Configuration_System
+
+    Prediction_Pipeline_Orchestrator -- "Configures" --> Configuration_System
+
+    click Configuration_System href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Configuration_System.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Configuration System is a cornerstone of this project's architecture, embodying the "Configuration-Driven Design" principle. It centralizes all configurable parameters, ensuring that settings for data processing, model architecture, and training/inference hyperparameters are managed systematically and are easily modifiable. This system leverages Hydra, enabling structured configuration, composition, and overriding of settings, which is crucial for reproducibility and experimentation in deep learning projects.
+
+
+
+### Configuration System [[Expand]](./Configuration_System.md)
+
+Manages and provides access to all project-wide configuration parameters. It uses Hydra to load, compose, and validate configurations from various YAML files, making them accessible to other components. This system is fundamental for defining hyperparameters, model architectures, data paths, and training/inference settings.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Training Pipeline Orchestrator
+
+Orchestrates the entire training workflow, from data loading and preprocessing to model training, evaluation, and logging. It consumes configurations provided by the Configuration System to set up the training environment, initialize models, define training parameters, and manage experiment tracking.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### Prediction Pipeline Orchestrator
+
+Manages the inference workflow, including loading trained models, preparing input data, performing predictions, and potentially post-processing results. It relies on the Configuration System to retrieve model paths, inference-specific parameters, and data handling settings.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Deep_Learning_Models.md
+++ b/.codeboarding/Deep_Learning_Models.md
@@ -1,0 +1,261 @@
+```mermaid
+
+graph LR
+
+    Model_Base["Model Base"]
+
+    MolE_Model["MolE Model"]
+
+    Encoder_Base["Encoder Base"]
+
+    Atom_Environment_Embeddings["Atom Environment Embeddings"]
+
+    BERT_Embeddings["BERT Embeddings"]
+
+    BERT_Layer["BERT Layer"]
+
+    BERT_Encoder["BERT Encoder"]
+
+    Disentangled_Self_Attention["Disentangled Self-Attention"]
+
+    Task_Prediction_Head["Task Prediction Head"]
+
+    Metrics_Dictionary["Metrics Dictionary"]
+
+    MolE_Model -- "inherits from" --> Model_Base
+
+    Model_Base -- "uses" --> Metrics_Dictionary
+
+    MolE_Model -- "inherits from" --> Model_Base
+
+    MolE_Model -- "uses" --> Atom_Environment_Embeddings
+
+    MolE_Model -- "uses" --> Task_Prediction_Head
+
+    Atom_Environment_Embeddings -- "inherits from" --> Encoder_Base
+
+    Task_Prediction_Head -- "inherits from" --> Encoder_Base
+
+    Atom_Environment_Embeddings -- "inherits from" --> Encoder_Base
+
+    Atom_Environment_Embeddings -- "uses" --> BERT_Embeddings
+
+    Atom_Environment_Embeddings -- "uses" --> BERT_Encoder
+
+    Atom_Environment_Embeddings -- "uses" --> BERT_Embeddings
+
+    BERT_Encoder -- "uses" --> BERT_Layer
+
+    Atom_Environment_Embeddings -- "uses" --> BERT_Encoder
+
+    BERT_Encoder -- "uses" --> BERT_Layer
+
+    Task_Prediction_Head -- "inherits from" --> Encoder_Base
+
+    MolE_Model -- "uses" --> Task_Prediction_Head
+
+    Model_Base -- "uses" --> Metrics_Dictionary
+
+    MolE_Model -- "uses" --> Metrics_Dictionary
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The Deep Learning Models subsystem is the core of the mole project, encapsulating the fundamental neural network architectures and components essential for molecular property prediction. It adheres to a modular design, separating concerns into abstract base models, specific model implementations, and reusable neural network building blocks. This structure facilitates extensibility, maintainability, and the integration of various deep learning techniques.
+
+
+
+### Model Base
+
+This is the foundational abstract class (mole.training.models.base.Model) for all trainable deep learning models. It establishes a standardized interface and common lifecycle methods (e.g., training_step, validation_step, test_step), ensuring consistency across different model implementations. It also integrates with the Metrics Dictionary for performance tracking.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/base.py#L22-L218" target="_blank" rel="noopener noreferrer">`mole.training.models.base.Model` (22:218)</a>
+
+
+
+
+
+### MolE Model
+
+The primary deep learning model (mole.training.models.mole.MolE) implemented in this project, specifically designed for molecular tasks. It extends Model Base and orchestrates the integration of various neural network components, such as Atom Environment Embeddings and Task Prediction Head, to perform end-to-end molecular property prediction. It encapsulates the full forward pass, loss calculation, and metric logging for training and validation steps.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py#L226-L326" target="_blank" rel="noopener noreferrer">`mole.training.models.mole.MolE` (226:326)</a>
+
+
+
+
+
+### Encoder Base
+
+An abstract base class (mole.training.models.encoder.Encoder) providing a common interface or base functionality for various encoder components within the deep learning models. This promotes reusability and a consistent structure for modules responsible for generating representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/encoder.py#L95-L143" target="_blank" rel="noopener noreferrer">`mole.training.models.encoder.Encoder` (95:143)</a>
+
+
+
+
+
+### Atom Environment Embeddings
+
+A specialized component (mole.training.models.mole.AtomEnvEmbeddings) responsible for generating contextualized embeddings for atomic environments within molecules. It leverages BERT Embeddings and BERT Encoder to capture rich, local chemical information, forming crucial input representations for downstream tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py#L30-L136" target="_blank" rel="noopener noreferrer">`mole.training.models.mole.AtomEnvEmbeddings` (30:136)</a>
+
+
+
+
+
+### BERT Embeddings
+
+Implements the initial embedding layer (mole.training.nn.bert.BertEmbeddings) for BERT-like models. It converts input tokens (e.g., atom features or indices) into dense vector representations, which serve as the starting point for the transformer encoder.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py#L309-L370" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert.BertEmbeddings` (309:370)</a>
+
+
+
+
+
+### BERT Layer
+
+A fundamental building block (mole.training.nn.bert.BertLayer) that encapsulates a single transformer layer. It typically includes self-attention mechanisms (like BERT Attention) and feed-forward networks, processing input sequences to generate higher-level representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py#L111-L144" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert.BertLayer` (111:144)</a>
+
+
+
+
+
+### BERT Encoder
+
+The core transformer encoder block (mole.training.nn.bert.BertEncoder), similar to the architecture found in BERT models. It consists of multiple BERT Layer instances and processes the input embeddings through self-attention mechanisms and feed-forward networks to generate higher-level, context-aware representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py#L183-L306" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert.BertEncoder` (183:306)</a>
+
+
+
+
+
+### Disentangled Self-Attention
+
+A specialized attention mechanism (mole.training.nn.disentangled_attention.DisentangledSelfAttention) used within the BERT Attention component of the BERT Encoder. It aims to improve representation learning by separating different aspects of attention (e.g., content-based vs. position-based), leading to more robust and interpretable models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/disentangled_attention.py#L18-L347" target="_blank" rel="noopener noreferrer">`mole.training.nn.disentangled_attention.DisentangledSelfAttention` (18:347)</a>
+
+
+
+
+
+### Task Prediction Head
+
+A neural network module (mole.training.nn.bert.TaskPredictionHead) responsible for taking the learned representations from the BERT Encoder (or other encoders) and transforming them into final predictions for specific downstream molecular tasks (e.g., property regression, classification).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py#L373-L412" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert.TaskPredictionHead` (373:412)</a>
+
+
+
+
+
+### Metrics Dictionary
+
+A utility class (mole.training.utils.metrics.MetricsDict) for managing and updating various performance metrics during model training and validation. It aggregates and organizes metrics for easy access, logging, and evaluation.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/utils/metrics.py#L17-L43" target="_blank" rel="noopener noreferrer">`mole.training.utils.metrics.MetricsDict` (17:43)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Prediction_Service.md
+++ b/.codeboarding/Prediction_Service.md
@@ -1,0 +1,201 @@
+```mermaid
+
+graph LR
+
+    Prediction_CLI["Prediction CLI"]
+
+    Data_Module_Dataset["Data Module & Dataset"]
+
+    Model_Inference_Orchestrator["Model Inference Orchestrator"]
+
+    PyTorch_Model_Loader_Executor["PyTorch Model Loader & Executor"]
+
+    ONNX_Model_Loader_Executor["ONNX Model Loader & Executor"]
+
+    Trained_Models_Repository["Trained Models Repository"]
+
+    PyTorch_Library["PyTorch Library"]
+
+    ONNX_Runtime_Library["ONNX Runtime Library"]
+
+    Prediction_CLI -- "initiates" --> Model_Inference_Orchestrator
+
+    Prediction_CLI -- "leverages" --> Data_Module_Dataset
+
+    Model_Inference_Orchestrator -- "utilizes" --> Data_Module_Dataset
+
+    Model_Inference_Orchestrator -- "dispatches to" --> PyTorch_Model_Loader_Executor
+
+    Model_Inference_Orchestrator -- "dispatches to" --> ONNX_Model_Loader_Executor
+
+    PyTorch_Model_Loader_Executor -- "loads model definitions and weights from" --> Trained_Models_Repository
+
+    PyTorch_Model_Loader_Executor -- "executes inference operations using the" --> PyTorch_Library
+
+    ONNX_Model_Loader_Executor -- "loads model definitions and weights from" --> Trained_Models_Repository
+
+    ONNX_Model_Loader_Executor -- "executes inference operations using the" --> ONNX_Runtime_Library
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Prediction Service` within the `mole` project is a critical component designed to manage the entire prediction workflow for molecular data. It acts as the public-facing API for inference, intelligently dispatching prediction requests based on the model format (PyTorch checkpoint or ONNX export). Its core purpose is to handle model loading, input data preparation, and the execution of forward passes to generate predictions.
+
+
+
+### Prediction CLI
+
+The primary command-line interface and public API for initiating prediction workflows. It parses user arguments (e.g., model path, input data) and orchestrates the overall prediction process by dispatching to the appropriate internal inference logic.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L188-L229" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict` (188:229)</a>
+
+
+
+
+
+### Data Module & Dataset
+
+Responsible for handling the entire data pipeline for prediction. This includes loading raw input data (e.g., SMILES strings), performing necessary preprocessing (e.g., converting SMILES to graph representations), and preparing data in batches suitable for model input. It ensures consistent data formatting across different models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/data_modules.py#L11-L207" target="_blank" rel="noopener noreferrer">`mole.training.data.data_modules:MolDataModule` (11:207)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/datasets.py#L15-L125" target="_blank" rel="noopener noreferrer">`mole.training.data.datasets:MolDataset` (15:125)</a>
+
+
+
+
+
+### Model Inference Orchestrator
+
+Manages the high-level logic for model loading and execution. It abstracts away the specifics of different model formats (PyTorch vs. ONNX) and decides which specialized inference engine to use based on the provided model type.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L188-L229" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict` (188:229)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L104-L139" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict_onnx` (104:139)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L142-L185" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict_ckpt` (142:185)</a>
+
+
+
+
+
+### PyTorch Model Loader & Executor
+
+Specializes in loading trained PyTorch model checkpoints and executing forward passes using the `torch` library. It handles the specific requirements for running inference with PyTorch-based models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L142-L185" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict_ckpt` (142:185)</a>
+
+
+
+
+
+### ONNX Model Loader & Executor
+
+Specializes in loading ONNX (Open Neural Network Exchange) exported models and executing forward passes using the `onnxruntime` library. This component is crucial for leveraging optimized and portable model formats.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L104-L139" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict_onnx` (104:139)</a>
+
+
+
+
+
+### Trained Models Repository
+
+Contains the definitions of the trained deep learning models (e.g., `MolE`, `Encoder`) and serves as the source for loading model architectures and their trained weights. It represents the intellectual property of the project in terms of learned representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py" target="_blank" rel="noopener noreferrer">`mole.training.models.mole`</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/encoder.py#L23-L92" target="_blank" rel="noopener noreferrer">`mole.training.models.encoder` (23:92)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/base.py" target="_blank" rel="noopener noreferrer">`mole.training.models.base`</a>
+
+
+
+
+
+### PyTorch Library
+
+An external deep learning framework providing fundamental tensor operations, neural network modules, and optimization algorithms. It is essential for defining, training, and inferring with PyTorch-based models.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### ONNX Runtime Library
+
+An external high-performance inference engine for ONNX models. It enables efficient execution of ONNX graphs across various hardware and operating systems, often with performance optimizations.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/Training_Evaluation_Manager.md
+++ b/.codeboarding/Training_Evaluation_Manager.md
@@ -1,0 +1,241 @@
+```mermaid
+
+graph LR
+
+    mole_cli_mole_train_train["mole.cli.mole_train:train"]
+
+    pytorch_lightning_Trainer["pytorch_lightning.Trainer"]
+
+    mole_training_data_data_modules_MolDataModule["mole.training.data.data_modules.MolDataModule"]
+
+    mole_training_models_base_Model["mole.training.models.base.Model"]
+
+    mole_training_models_mole_MolE["mole.training.models.mole.MolE"]
+
+    mole_training_models_encoder_Encoder["mole.training.models.encoder.Encoder"]
+
+    mole_training_nn_bert["mole.training.nn.bert"]
+
+    mole_training_utils_metrics["mole.training.utils.metrics"]
+
+    mole_training_utils_schedulers["mole.training.utils.schedulers"]
+
+    mole_training_models_utils_masks["mole.training.models.utils.masks"]
+
+    mole_cli_mole_train_train -- "orchestrates" --> pytorch_lightning_Trainer
+
+    mole_cli_mole_train_train -- "instantiates and configures" --> mole_training_data_data_modules_MolDataModule
+
+    mole_cli_mole_train_train -- "instantiates and configures" --> mole_training_models_base_Model
+
+    pytorch_lightning_Trainer -- "interacts with" --> mole_training_models_base_Model
+
+    pytorch_lightning_Trainer -- "consumes data from" --> mole_training_data_data_modules_MolDataModule
+
+    mole_training_models_base_Model -- "utilizes" --> mole_training_utils_metrics
+
+    mole_training_models_base_Model -- "utilizes" --> mole_training_models_utils_masks
+
+    mole_training_models_mole_MolE -- "inherits from" --> mole_training_models_base_Model
+
+    mole_training_models_mole_MolE -- "incorporates components from" --> mole_training_models_encoder_Encoder
+
+    mole_training_models_mole_MolE -- "incorporates components from" --> mole_training_nn_bert
+
+    mole_cli_mole_train_train -- "uses" --> mole_training_utils_schedulers
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `Training & Evaluation Manager` subsystem is the core of the `mole` project's deep learning capabilities, embodying a Pipeline Architecture and Configuration-Driven Design. It orchestrates the entire lifecycle of model training and evaluation, from data preparation to model deployment.
+
+
+
+### mole.cli.mole_train:train
+
+This function serves as the primary entry point and orchestrator for the entire training and evaluation pipeline. It is responsible for reading the configuration (likely via Hydra), instantiating the `PyTorch Lightning Trainer`, the `MolDataModule`, and the specific `Model` to be trained. It also handles crucial setup steps like seeding for reproducibility, preparing data, calculating learning rate schedules, logging hyperparameters, and finally initiating the training process via `trainer.fit()`. It's fundamental as the high-level control flow manager.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_train.py#L64-L105" target="_blank" rel="noopener noreferrer">`mole.cli.mole_train:train` (64:105)</a>
+
+
+
+
+
+### pytorch_lightning.Trainer
+
+This is the central execution engine provided by PyTorch Lightning. It abstracts away the complexities of the training loop, handling forward and backward passes, optimization, logging, checkpointing, and distributed training. It interacts directly with the `Model` and `DataModule` to execute the training and validation steps. It's fundamental because it provides the robust and scalable infrastructure for deep learning training.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### mole.training.data.data_modules.MolDataModule
+
+This component is responsible for managing the entire data pipeline, including loading, preprocessing, and batching of molecular data. It provides `DataLoader` instances for training, validation, and testing phases to the `Trainer`. It also encapsulates data preparation logic, such as downloading datasets if necessary. It's fundamental for implementing a Data-Centric Architecture, ensuring efficient and consistent data flow.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/data_modules.py#L11-L207" target="_blank" rel="noopener noreferrer">`mole.training.data.data_modules.MolDataModule` (11:207)</a>
+
+
+
+
+
+### mole.training.models.base.Model
+
+This serves as the abstract base class for all deep learning models within the `mole.training` framework. It defines a consistent interface for common model operations, including `training_step`, `validation_step`, `test_step`, and metric logging. Concrete model implementations inherit from this class, ensuring architectural consistency and extensibility. It's fundamental for defining the "Model" aspect of the conceptual MVC pattern.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/base.py#L22-L218" target="_blank" rel="noopener noreferrer">`mole.training.models.base.Model` (22:218)</a>
+
+
+
+
+
+### mole.training.models.mole.MolE
+
+This is a concrete implementation of a molecular deep learning model, inheriting from `mole.training.models.base.Model`. It encapsulates the specific neural network architecture and forward pass logic for molecular embeddings and predictions. It represents the actual deep learning model being trained and evaluated. It's fundamental as the specific "subject" of the training process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py#L226-L326" target="_blank" rel="noopener noreferrer">`mole.training.models.mole.MolE` (226:326)</a>
+
+
+
+
+
+### mole.training.models.encoder.Encoder
+
+This component likely serves as a base or abstract class for various encoder architectures used within the `MolE` model or other molecular models. Encoders are crucial for transforming raw molecular data into meaningful numerical representations that the neural network can process. It's fundamental as a reusable building block for complex model architectures.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/encoder.py#L95-L143" target="_blank" rel="noopener noreferrer">`mole.training.models.encoder.Encoder` (95:143)</a>
+
+
+
+
+
+### mole.training.nn.bert
+
+This module contains various BERT-like neural network components (e.g., `BertAttention`, `BertEmbeddings`, `BertEncoder`, `TaskPredictionHead`). These components are fundamental building blocks for constructing advanced molecular models, especially those leveraging transformer-like architectures for sequence or graph data. They provide the core neural network layers for learning complex representations.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert`</a>
+
+
+
+
+
+### mole.training.utils.metrics
+
+This utility module provides functions and classes for calculating, aggregating, and reporting various evaluation metrics (e.g., regression metrics, classification metrics). It's crucial for monitoring model performance during training and evaluation, enabling informed decisions about model optimization. It's fundamental for the "Evaluation" aspect of the pipeline.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/utils/metrics.py" target="_blank" rel="noopener noreferrer">`mole.training.utils.metrics`</a>
+
+
+
+
+
+### mole.training.utils.schedulers
+
+This utility module contains helper functions for managing learning rate schedules, such as calculating the number of warmup steps based on the total training steps. Learning rate scheduling is a critical optimization technique for stable and efficient model training. It's fundamental for fine-tuning the training process.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/utils/schedulers.py" target="_blank" rel="noopener noreferrer">`mole.training.utils.schedulers`</a>
+
+
+
+
+
+### mole.training.models.utils.masks
+
+This utility module provides functions for creating or manipulating masks. Masks are often used in attention mechanisms within molecular models to handle variable-length inputs, pad sequences, or focus on specific parts of a molecular graph. It's fundamental for correctly processing and interpreting complex molecular data within the neural network.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/utils/masks.py" target="_blank" rel="noopener noreferrer">`mole.training.models.utils.masks`</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/User_Interface_CLI_.md
+++ b/.codeboarding/User_Interface_CLI_.md
@@ -1,0 +1,229 @@
+```mermaid
+
+graph LR
+
+    User_Interface_CLI_["User Interface (CLI)"]
+
+    Configuration_System["Configuration System"]
+
+    Training_Pipeline_Orchestrator["Training Pipeline Orchestrator"]
+
+    Prediction_Pipeline_Orchestrator["Prediction Pipeline Orchestrator"]
+
+    Data_Management_Module["Data Management Module"]
+
+    Core_Models["Core Models"]
+
+    PyTorch_Lightning_Framework["PyTorch Lightning Framework"]
+
+    ONNX_Runtime["ONNX Runtime"]
+
+    User_Interface_CLI_ -- "invokes" --> Training_Pipeline_Orchestrator
+
+    User_Interface_CLI_ -- "invokes" --> Prediction_Pipeline_Orchestrator
+
+    User_Interface_CLI_ -- "configures" --> Configuration_System
+
+    Training_Pipeline_Orchestrator -- "utilizes" --> Configuration_System
+
+    Training_Pipeline_Orchestrator -- "utilizes" --> Data_Management_Module
+
+    Training_Pipeline_Orchestrator -- "trains" --> Core_Models
+
+    Training_Pipeline_Orchestrator -- "utilizes" --> PyTorch_Lightning_Framework
+
+    Prediction_Pipeline_Orchestrator -- "utilizes" --> Configuration_System
+
+    Prediction_Pipeline_Orchestrator -- "utilizes" --> Data_Management_Module
+
+    Prediction_Pipeline_Orchestrator -- "infers with" --> Core_Models
+
+    Prediction_Pipeline_Orchestrator -- "utilizes" --> ONNX_Runtime
+
+    Prediction_Pipeline_Orchestrator -- "utilizes" --> PyTorch_Lightning_Framework
+
+    Configuration_System -- "provides configuration to" --> Training_Pipeline_Orchestrator
+
+    Configuration_System -- "provides configuration to" --> Prediction_Pipeline_Orchestrator
+
+    Data_Management_Module -- "provides data to" --> Training_Pipeline_Orchestrator
+
+    Data_Management_Module -- "provides data to" --> Prediction_Pipeline_Orchestrator
+
+    Core_Models -- "used by" --> Training_Pipeline_Orchestrator
+
+    Core_Models -- "used by" --> Prediction_Pipeline_Orchestrator
+
+    PyTorch_Lightning_Framework -- "used by" --> Training_Pipeline_Orchestrator
+
+    PyTorch_Lightning_Framework -- "used by" --> Prediction_Pipeline_Orchestrator
+
+    ONNX_Runtime -- "used by" --> Prediction_Pipeline_Orchestrator
+
+    click User_Interface_CLI_ href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//User_Interface_CLI_.md" "Details"
+
+    click Configuration_System href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Configuration_System.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+The `User Interface (CLI)` component serves as the primary user-facing entry point for the `mole_public` application. It is designed as a thin wrapper, responsible for parsing command-line arguments and orchestrating the execution of core training and prediction workflows by delegating to specialized managers.
+
+
+
+### User Interface (CLI) [[Expand]](./User_Interface_CLI_.md)
+
+This component provides the command-line interfaces for users to interact with the `mole_public` application. It parses user inputs and acts as the orchestrator, initiating either model training or prediction/embedding generation by invoking the appropriate pipeline orchestrators.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `cli_entry_point` (1:1)
+
+- `cli_entry_point` (1:1)
+
+
+
+
+
+### Configuration System [[Expand]](./Configuration_System.md)
+
+Manages application configurations using Hydra. It provides a structured way to define and load parameters for models, data, training, and inference, enabling a "Configuration-Driven Design."
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `configuration_management` (1:1)
+
+- `configuration_management` (1:1)
+
+
+
+
+
+### Training Pipeline Orchestrator
+
+Encapsulates the end-to-end logic for model training. It receives commands from the CLI, loads configurations, sets up the data module, instantiates the model, and initiates the training process using PyTorch Lightning. It embodies the "Pipeline Architecture" for training.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_train.py#L64-L105" target="_blank" rel="noopener noreferrer">`mole/cli/mole_train.py:train` (64:105)</a>
+
+
+
+
+
+### Prediction Pipeline Orchestrator
+
+Manages the inference workflow, supporting both ONNX and PyTorch Lightning checkpoint-based predictions, as well as embedding generation. It receives commands from the CLI, sets up the data module for prediction, and invokes the appropriate inference logic. It embodies the "Pipeline Architecture" for inference.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L53-L101" target="_blank" rel="noopener noreferrer">`mole/cli/mole_predict.py:encode` (53:101)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L104-L139" target="_blank" rel="noopener noreferrer">`mole/cli/mole_predict.py:predict_onnx` (104:139)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L142-L185" target="_blank" rel="noopener noreferrer">`mole/cli/mole_predict.py:predict_ckpt` (142:185)</a>
+
+
+
+
+
+### Data Management Module
+
+Handles all aspects of data loading, preprocessing, and batching for both training and prediction. It ensures data is correctly prepared for the deep learning models.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/data_modules.py#L11-L207" target="_blank" rel="noopener noreferrer">`mole/training/data/data_modules.py:MolDataModule` (11:207)</a>
+
+
+
+
+
+### Core Models
+
+Contains the actual deep learning model architectures used for training and inference, such as the base `Model` and `Encoder`. These are the "brains" of the application, performing the core computational tasks.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- `model_definition` (1:1)
+
+- `model_definition` (1:1)
+
+
+
+
+
+### PyTorch Lightning Framework
+
+A high-level PyTorch framework that simplifies the deep learning training and prediction loops. It provides abstractions for trainers, models, and data modules, promoting organized and reproducible research.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+### ONNX Runtime
+
+An open-source cross-platform machine learning inferencing accelerator. It is used by the Prediction Pipeline Orchestrator to perform highly optimized inference with ONNX-exported models.
+
+
+
+
+
+**Related Classes/Methods**: _None_
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)

--- a/.codeboarding/on_boarding.md
+++ b/.codeboarding/on_boarding.md
@@ -1,0 +1,207 @@
+```mermaid
+
+graph LR
+
+    User_Interface_CLI_["User Interface (CLI)"]
+
+    Configuration_System["Configuration System"]
+
+    Data_Pipeline["Data Pipeline"]
+
+    Deep_Learning_Models["Deep Learning Models"]
+
+    Training_Evaluation_Manager["Training & Evaluation Manager"]
+
+    Prediction_Service["Prediction Service"]
+
+    User_Interface_CLI_ -- "Invokes" --> Training_Evaluation_Manager
+
+    User_Interface_CLI_ -- "Invokes" --> Prediction_Service
+
+    User_Interface_CLI_ -- "Accesses" --> Configuration_System
+
+    Configuration_System -- "Configures" --> Data_Pipeline
+
+    Configuration_System -- "Configures" --> Deep_Learning_Models
+
+    Configuration_System -- "Configures" --> Training_Evaluation_Manager
+
+    Configuration_System -- "Configures" --> Prediction_Service
+
+    Data_Pipeline -- "Provides Data To" --> Training_Evaluation_Manager
+
+    Data_Pipeline -- "Provides Data To" --> Prediction_Service
+
+    Deep_Learning_Models -- "Used By" --> Training_Evaluation_Manager
+
+    Deep_Learning_Models -- "Used By" --> Prediction_Service
+
+    Training_Evaluation_Manager -- "Trains" --> Deep_Learning_Models
+
+    Training_Evaluation_Manager -- "Receives Data From" --> Data_Pipeline
+
+    Prediction_Service -- "Executes" --> Deep_Learning_Models
+
+    Prediction_Service -- "Receives Data From" --> Data_Pipeline
+
+    click User_Interface_CLI_ href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//User_Interface_CLI_.md" "Details"
+
+    click Configuration_System href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Configuration_System.md" "Details"
+
+    click Deep_Learning_Models href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Deep_Learning_Models.md" "Details"
+
+    click Training_Evaluation_Manager href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Training_Evaluation_Manager.md" "Details"
+
+    click Prediction_Service href "https://github.com/recursionpharma/mole_public/blob/trunk/.codeboarding//Prediction_Service.md" "Details"
+
+```
+
+
+
+[![CodeBoarding](https://img.shields.io/badge/Generated%20by-CodeBoarding-9cf?style=flat-square)](https://github.com/CodeBoarding/GeneratedOnBoardings)[![Demo](https://img.shields.io/badge/Try%20our-Demo-blue?style=flat-square)](https://www.codeboarding.org/demo)[![Contact](https://img.shields.io/badge/Contact%20us%20-%20contact@codeboarding.org-lightgrey?style=flat-square)](mailto:contact@codeboarding.org)
+
+
+
+## Details
+
+
+
+Final Architecture Analysis for `mole_public`
+
+
+
+### User Interface (CLI) [[Expand]](./User_Interface_CLI_.md)
+
+Serves as the primary user-facing entry point, parsing command-line arguments and orchestrating the execution of training and prediction workflows. It acts as a thin wrapper, delegating core logic to specialized managers.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_train.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.cli.mole_train` (1:1)</a>
+
+
+
+
+
+### Configuration System [[Expand]](./Configuration_System.md)
+
+Centralizes and manages all configurable parameters for the project, encompassing settings for data processing, model architecture, and training/inference hyperparameters, leveraging Hydra for structured configuration.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.configs` (1:1)</a>
+
+
+
+
+
+### Data Pipeline
+
+Manages all aspects of data handling, including loading raw molecular data, preprocessing (e.g., tokenization, graph construction), vocabulary management, and generating PyTorch Lightning DataModules and Datasets for efficient batching during training and inference.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/data_modules.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.data.data_modules` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/datasets.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.data.datasets` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/data/utils.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.data.utils` (1:1)</a>
+
+- `mole.training.data.vocabularies` (1:1)
+
+
+
+
+
+### Deep Learning Models [[Expand]](./Deep_Learning_Models.md)
+
+Encapsulates the core deep learning architectures, including a foundational abstract base model, the specific MolE model, generic encoders, and fundamental neural network building blocks (e.g., BERT-like components, attention mechanisms).
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/base.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.models.base` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/mole.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.models.mole` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/encoder.py#L23-L92" target="_blank" rel="noopener noreferrer">`mole.training.models.encoder` (23:92)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/bert.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.nn.bert` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/nn/disentangled_attention.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.nn.disentangled_attention` (1:1)</a>
+
+
+
+
+
+### Training & Evaluation Manager [[Expand]](./Training_Evaluation_Manager.md)
+
+Coordinates the entire model training and evaluation pipeline. It initializes models and data loaders, executes the training loop (largely driven by PyTorch Lightning's Trainer), handles logging, checkpointing, and calculates various performance metrics.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_train.py#L64-L105" target="_blank" rel="noopener noreferrer">`mole.cli.mole_train:train` (64:105)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/utils/metrics.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.utils.metrics` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/utils/schedulers.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.utils.schedulers` (1:1)</a>
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/training/models/utils/masks.py#L1-L1" target="_blank" rel="noopener noreferrer">`mole.training.models.utils.masks` (1:1)</a>
+
+
+
+
+
+### Prediction Service [[Expand]](./Prediction_Service.md)
+
+Manages the prediction workflow. It loads trained models (either PyTorch checkpoints or ONNX exports), prepares input data, and performs forward passes to generate predictions for new molecular data.
+
+
+
+
+
+**Related Classes/Methods**:
+
+
+
+- <a href="https://github.com/recursionpharma/mole_public/blob/trunk/mole/cli/mole_predict.py#L188-L229" target="_blank" rel="noopener noreferrer">`mole.cli.mole_predict:predict` (188:229)</a>
+
+
+
+
+
+
+
+
+
+### [FAQ](https://github.com/CodeBoarding/GeneratedOnBoardings/tree/main?tab=readme-ov-file#faq)


### PR DESCRIPTION
This PR includes diagram-based documentation which shows the main components of the codebase and how they interact with each other. You can see how they render here:
https://github.com/CodeBoarding/GeneratedOnBoardings/blob/main/mole_public/on_boarding.md

These diagrams are designed to make research codebases more approachable—especially for scientists and researchers who work with code to support analysis, rather than as professional software engineers.

We generate these diagrams using a mix of static analysis and LLMs. There’s also a GitHub Action you can add to your repository—it automatically keeps the diagrams up to date with every merge to main, release, or other branches you configure (also it can add the docs in to the `/docs` folder).

We’d love to connect and learn more about your workflow—especially around onboarding, reproducibility, or cross-functional collaboration. If you’re open to a quick chat, we’d be excited to explore how we can help.

Thanks for your time!